### PR TITLE
fix: execute notification center completion handlers on the main thread

### DIFF
--- a/Sources/PushMessaging/MessagingPush+AppDelegate.swift
+++ b/Sources/PushMessaging/MessagingPush+AppDelegate.swift
@@ -32,7 +32,9 @@ import OrttoSDKCore
             }
 
             if !UIApplication.shared.canOpenURL(url) {
-                completionHandler()
+                DispatchQueue.main.async {
+                    completionHandler()
+                }
                 return false
             }
 
@@ -43,7 +45,9 @@ import OrttoSDKCore
             }
 
             Ortto.shared.trackLinkClick(deepLink) {
-                completionHandler()
+                DispatchQueue.main.async {
+                    completionHandler()
+                }
             }
 
             return true


### PR DESCRIPTION
Hi Ortto team 👋

While testing push notifications on iOS, I noticed that the app crashes after tapping on a notification. XCode provided a hint pointing to the `MessagingPush+AppDelegate.swift` file.

<img width="1230" alt="Screenshot_2025-04-04_at_10 47 35" src="https://github.com/user-attachments/assets/56fb535d-1819-4268-bed9-4a04b5ff457e" />

It turns out that the `completionHandler` is being called off the main thread, which seems to cause issues — probably due to a UI-related action like navigating to a specific tab.

I tried wrapping the `completionHandler` in `DispatchQueue.main.async`, and that resolved the crash. To be safe, I applied the same change everywhere `completionHandler` is used.

The fix has been tested and appears to work well on my side.

Happy to help further if needed — let me know if you have a different approach in mind!