### PR TITLE
Fix: dynamic notification action buttons

### DIFF
--- a/Sources/PushMessaging/MessagingService.swift
+++ b/Sources/PushMessaging/MessagingService.swift
@@ -98,8 +98,9 @@ public class MessagingService: MessagingServiceProtocol {
         }
 
         let http = httpClientFactory()
-        let content = buildContent(from: pushPayload, categoryID: request.content.categoryIdentifier)
-        let category = buildCategory(from: pushPayload, categoryID: request.content.categoryIdentifier)
+        let categoryID = Self.categoryIdentifier(for: pushPayload, requested: request.content.categoryIdentifier)
+        let content = buildContent(from: pushPayload, categoryID: categoryID)
+        let category = buildCategory(from: pushPayload, categoryID: categoryID)
         let delivery = NotificationDelivery(content: content, contentHandler: contentHandler)
         addDelivery(delivery)
 
@@ -162,9 +163,11 @@ public class MessagingService: MessagingServiceProtocol {
     ) -> UNMutableNotificationContent {
         var actionLinks: [String: String] = [:]
 
-        for action in payload.actions {
-            guard let identifier = action.action else { continue }
-            actionLinks[identifier] = action.link
+        // Index, not action.action — the backend sends the action TYPE (e.g. "page"),
+        // which repeats across buttons; using it as the id collides. Must match the
+        // UNNotificationAction id built in buildCategory so a tap resolves the right link.
+        for (index, action) in payload.actions.enumerated() {
+            actionLinks["\(categoryID).\(index)"] = action.link
         }
 
         if let primaryAction = payload.primaryAction {
@@ -184,10 +187,9 @@ public class MessagingService: MessagingServiceProtocol {
         from payload: PushNotificationPayload,
         categoryID: String
     ) -> UNNotificationCategory {
-        let actions: [UNNotificationAction] = payload.actions.compactMap { item in
-            guard let identifier = item.action else { return nil }
-            return UNNotificationAction(
-                identifier: identifier,
+        let actions: [UNNotificationAction] = payload.actions.enumerated().map { index, item in
+            UNNotificationAction(
+                identifier: "\(categoryID).\(index)",
                 title: item.title ?? "",
                 options: [.foreground]
             )
@@ -213,18 +215,43 @@ public class MessagingService: MessagingServiceProtocol {
         }
     }
 
-    /// Registers a notification category with the system notification center.
+    // Each push gets its own category id so a new notification can't reuse
+    // the previous push's item IDs.
+    private static let dynamicCategoryPrefix = "ORTTO_ACTIONS."
+    private static let maxDynamicCategories = 64
+
+    /// A unique category id for this push, so its buttons always match its own actions.
+    /// The send time is zero-padded so sorting the ids alphabetically is also oldest-first.
+    static func categoryIdentifier(for payload: PushNotificationPayload, requested: String) -> String {
+        guard !payload.actions.isEmpty else { return requested }
+        let sendTime = String(format: "%015ld", Int(Date().timeIntervalSince1970 * 1000))
+        return "\(dynamicCategoryPrefix)\(sendTime).\(payload.notificationID)"
+    }
+
+    /// Adds `category`, replacing any with the same id, then keeps only the newest
+    /// `maxDynamicCategories` ids this SDK created (oldest dropped first).
+    static func categories(
+        byAdding category: UNNotificationCategory,
+        to existing: Set<UNNotificationCategory>
+    ) -> Set<UNNotificationCategory> {
+        var kept = existing.filter { $0.identifier != category.identifier }
+        kept.insert(category)
+
+        let oursOldestFirst = kept.map(\.identifier)
+            .filter { $0.hasPrefix(dynamicCategoryPrefix) }
+            .sorted()
+        let stale = Set(oursOldestFirst.dropLast(maxDynamicCategories))
+        return kept.filter { !stale.contains($0.identifier) }
+    }
+
     private static func registerCategoryWithNotificationCenter(
         _ category: UNNotificationCategory
     ) async -> Bool {
         await withCheckedContinuation { continuation in
-            UNUserNotificationCenter.current().getNotificationCategories { existing in
-                var all = existing
-                all.insert(category)
-                UNUserNotificationCenter.current().setNotificationCategories(all)
-                UNUserNotificationCenter.current().getNotificationCategories { _ in
-                    continuation.resume(returning: true)
-                }
+            let center = UNUserNotificationCenter.current()
+            center.getNotificationCategories { existing in
+                center.setNotificationCategories(categories(byAdding: category, to: existing))
+                center.getNotificationCategories { _ in continuation.resume(returning: true) }
             }
         }
     }

--- a/Sources/PushMessaging/MessagingService.swift
+++ b/Sources/PushMessaging/MessagingService.swift
@@ -92,6 +92,9 @@ public class MessagingService: MessagingServiceProtocol {
         _ request: UNNotificationRequest,
         withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
     ) -> Bool {
+        // TEMP(testing): capture the raw incoming payload to see exactly what the backend
+        // sends — especially whether each action carries an `action` identifier.
+        Ortto.log().info("MessagingService@didReceive.raw actions=\(request.content.userInfo["actions"] ?? "nil") primary_action=\(request.content.userInfo["primary_action"] ?? "nil") keys=\(Array(request.content.userInfo.keys))")
         guard let pushPayload = PushNotificationPayload.parse(request.content) else {
             Ortto.log().warn("MessagingService@didReceive.content.parse-fail")
             return false
@@ -107,8 +110,15 @@ public class MessagingService: MessagingServiceProtocol {
         delivery.task = Task { [weak self, weak delivery] in
             guard let self, let delivery else { return }
 
+            // Register the category FIRST, before any slow or cancellable work. Action buttons
+            // only render if the category is registered when the content is delivered, and on NSE
+            // expiry `expire()` cancels this Task and delivers immediately. Registering up front
+            // (above the cancellation guard) means a slow image download — or expiry mid-download —
+            // can never strip the buttons.
+            _ = await self.categoryRegistrar(category)
+
             async let attachment = NotificationAttachmentDownloader(httpClient: http)
-                .optionalAttachment(from: pushPayload.image)
+                .optionalAttachment(from: pushPayload.image, timeout: 20)
             async let tracking: Void = self.trackDelivery(pushPayload.eventTrackingUrl, using: http)
 
             if let imageAttachment = await attachment {
@@ -119,7 +129,6 @@ public class MessagingService: MessagingServiceProtocol {
 
             guard !Task.isCancelled else { return }
 
-            _ = await self.categoryRegistrar(category)
             delivery.deliver()
             self.removeDelivery(delivery)
         }
@@ -215,8 +224,8 @@ public class MessagingService: MessagingServiceProtocol {
         }
     }
 
-    // Each push gets its own category id so a new notification can't reuse
-    // the previous push's item IDs.
+    // Each push gets its own category id to avoid otherwise new notification reusing
+    // the previous push item ID's
     private static let dynamicCategoryPrefix = "ORTTO_ACTIONS."
     private static let maxDynamicCategories = 64
 

--- a/Sources/PushMessaging/MessagingService.swift
+++ b/Sources/PushMessaging/MessagingService.swift
@@ -92,9 +92,6 @@ public class MessagingService: MessagingServiceProtocol {
         _ request: UNNotificationRequest,
         withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
     ) -> Bool {
-        // TEMP(testing): capture the raw incoming payload to see exactly what the backend
-        // sends — especially whether each action carries an `action` identifier.
-        Ortto.log().info("MessagingService@didReceive.raw actions=\(request.content.userInfo["actions"] ?? "nil") primary_action=\(request.content.userInfo["primary_action"] ?? "nil") keys=\(Array(request.content.userInfo.keys))")
         guard let pushPayload = PushNotificationPayload.parse(request.content) else {
             Ortto.log().warn("MessagingService@didReceive.content.parse-fail")
             return false
@@ -224,17 +221,16 @@ public class MessagingService: MessagingServiceProtocol {
         }
     }
 
-    // Each push gets its own category id to avoid otherwise new notification reusing
-    // the previous push item ID's
+    // Each push gets its own category id so a new notification can't reuse a previous push's action IDs.
     private static let dynamicCategoryPrefix = "ORTTO_ACTIONS."
     private static let maxDynamicCategories = 64
 
     /// A unique category id for this push, so its buttons always match its own actions.
-    /// The send time is zero-padded so sorting the ids alphabetically is also oldest-first.
+    /// The creation time is zero-padded so sorting the ids alphabetically is also oldest-first.
     static func categoryIdentifier(for payload: PushNotificationPayload, requested: String) -> String {
         guard !payload.actions.isEmpty else { return requested }
-        let sendTime = String(format: "%015ld", Int(Date().timeIntervalSince1970 * 1000))
-        return "\(dynamicCategoryPrefix)\(sendTime).\(payload.notificationID)"
+        let createdAt = String(format: "%015ld", Int(Date().timeIntervalSince1970 * 1000))
+        return "\(dynamicCategoryPrefix)\(createdAt).\(payload.notificationID)"
     }
 
     /// Adds `category`, replacing any with the same id, then keeps only the newest

--- a/Sources/PushMessaging/NotificationAttachmentDownloader.swift
+++ b/Sources/PushMessaging/NotificationAttachmentDownloader.swift
@@ -28,14 +28,30 @@ import OrttoSDKCore
             )
         }
 
-        /// Returns nil when the payload has no usable image or the attachment cannot be created.
-        func optionalAttachment(from imageURLString: String?) async -> UNNotificationAttachment? {
+        /// Returns nil when the payload has no usable image, the attachment cannot be created,
+        /// or the download takes longer than `timeout` seconds. The timeout keeps a slow image
+        /// from consuming the whole NSE budget so the notification still delivers (with its text
+        /// and action buttons) before the extension expires.
+        func optionalAttachment(
+            from imageURLString: String?,
+            timeout: TimeInterval = 20
+        ) async -> UNNotificationAttachment? {
             guard let imageURLString, let imageURL = URL(string: imageURLString) else {
                 return nil
             }
 
             do {
-                return try await attachment(from: imageURL)
+                return try await withThrowingTaskGroup(of: UNNotificationAttachment?.self) { group in
+                    group.addTask { try await self.attachment(from: imageURL) }
+                    group.addTask {
+                        try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                        return nil
+                    }
+                    // Whichever finishes first wins; cancel the loser (the download or the timer).
+                    let result = try await group.next() ?? nil
+                    group.cancelAll()
+                    return result
+                }
             } catch {
                 Ortto.log().debug("NotificationAttachmentDownloader@attachment.fail \(error.localizedDescription)")
                 return nil

--- a/Tests/OrttoSDKTests/MessagingServiceInterceptTests.swift
+++ b/Tests/OrttoSDKTests/MessagingServiceInterceptTests.swift
@@ -76,22 +76,79 @@ import XCTest
             let content = try XCTUnwrap(deliveredContent)
             XCTAssertEqual(content.title, "New release")
             XCTAssertEqual(content.body, "The notification service extension rewrote this body.")
-            XCTAssertEqual(content.categoryIdentifier, "ortto-push-category")
             XCTAssertEqual(content.sound, .default)
             XCTAssertEqual(content.attachments.count, 1)
             XCTAssertEqual(content.attachments.first?.identifier, "image")
 
-            let userInfo = try XCTUnwrap(content.userInfo as? [String: String])
-            XCTAssertEqual(userInfo["open_release"], "ortto://release")
-            XCTAssertEqual(userInfo["view_docs"], "ortto://docs")
-            XCTAssertEqual(userInfo[UNNotificationDefaultActionIdentifier], "ortto://primary")
-
+            // The category id is unique per notification (ORTTO_ACTIONS.<ts>.<notificationID>),
+            // not the shared id from the payload, and the content points at it.
             let category = try XCTUnwrap(categoryRecorder.latestCategory)
-            XCTAssertEqual(category.identifier, "ortto-push-category")
-            XCTAssertEqual(category.actions.map(\.identifier), ["open_release", "view_docs"])
+            XCTAssertTrue(category.identifier.hasPrefix("ORTTO_ACTIONS."))
+            XCTAssertTrue(category.identifier.hasSuffix(".message-123"))
+            XCTAssertEqual(content.categoryIdentifier, category.identifier)
+
+            // Buttons keep their titles + order, but identifiers are per-index (not the
+            // repeating `action` field), so duplicate action types can't collide.
+            XCTAssertEqual(category.actions.map(\.title), ["Open", "Docs"])
+            XCTAssertEqual(
+                category.actions.map(\.identifier),
+                ["\(category.identifier).0", "\(category.identifier).1"]
+            )
+
+            // Each button's link is stored under its own identifier; default action too.
+            let userInfo = try XCTUnwrap(content.userInfo as? [String: String])
+            XCTAssertEqual(userInfo["\(category.identifier).0"], "ortto://release")
+            XCTAssertEqual(userInfo["\(category.identifier).1"], "ortto://docs")
+            XCTAssertEqual(userInfo[UNNotificationDefaultActionIdentifier], "ortto://primary")
 
             XCTAssertEqual(httpClient.downloadRequests.count, 1)
             XCTAssertEqual(httpClient.sentRequests.count, 1)
+        }
+
+        // MARK: - Duplicate action types (real prod shape)
+
+        /// Ortto sends the action TYPE in `action` (e.g. "page"), repeated across buttons.
+        /// The SDK must give each button a distinct identifier and keep every link — using
+        /// `action` as the id makes both buttons collide onto the last link.
+        func testDuplicateActionTypesStayDistinct() throws {
+            let httpClient = MockOrttoHTTPClient()
+            let categoryRecorder = NotificationCategoryRecorder()
+            let service = MessagingService(
+                httpClientFactory: { httpClient },
+                categoryRegistrar: { category in await categoryRecorder.register(category) }
+            )
+
+            let content = UNMutableNotificationContent()
+            content.categoryIdentifier = "ORTTO_ACTIONS"
+            content.userInfo = [
+                "ortto_notification_id": "dup-1",
+                "title": "t",
+                "body": "b",
+                "actions": """
+                    [
+                        {"action":"page","title":"One","link":"ortto://one"},
+                        {"action":"page","title":"Two","link":"ortto://two"}
+                    ]
+                    """
+            ]
+            let request = UNNotificationRequest(identifier: "dup-req", content: content, trigger: nil)
+
+            let delivered = expectation(description: "delivered")
+            var deliveredContent: UNNotificationContent?
+            XCTAssertTrue(service.didReceive(request) { content in
+                deliveredContent = content
+                delivered.fulfill()
+            })
+            wait(for: [delivered], timeout: 5)
+
+            let category = try XCTUnwrap(categoryRecorder.latestCategory)
+            let ids = category.actions.map(\.identifier)
+            XCTAssertEqual(ids.count, 2)
+            XCTAssertEqual(Set(ids).count, 2, "action identifiers must be unique despite identical `action` types")
+
+            // Both links survive — the bug overwrote the first under the shared "page" key.
+            let userInfo = try XCTUnwrap(deliveredContent?.userInfo as? [String: String])
+            XCTAssertEqual(category.actions.map { userInfo[$0.identifier] }, ["ortto://one", "ortto://two"])
         }
 
         // MARK: - Non-Ortto payload


### PR DESCRIPTION
Fixes an issue where a notification that comes in after a previous one reuses the notification category ID's and never recycles them. 