### PR TITLE
Fix: device never re-registers for push when the first registration fails or identity arrives late

### DIFF
--- a/Sources/PushMessaging/Ortto+PushMessaging.swift
+++ b/Sources/PushMessaging/Ortto+PushMessaging.swift
@@ -33,10 +33,12 @@ public extension Ortto {
      */
     internal func updatePushToken(token: PushToken, force: Bool = false) {
         if force {
-            // Re-send even if the token is unchanged — needed when the session or
-            // permission changed after the token was first cached.
+            // Send straight to the API, skipping the token setter's unchanged-token
+            // guard. Needed when the token itself hasn't changed but the session or
+            // permission has (e.g. identify completed after the token was cached).
             PushMessaging.shared.sendPushRegistration(token)
         } else {
+            // Normal path: the setter dedupes against the cached token before sending.
             PushMessaging.shared.token = token
         }
     }

--- a/Sources/PushMessaging/Ortto+PushMessaging.swift
+++ b/Sources/PushMessaging/Ortto+PushMessaging.swift
@@ -32,7 +32,13 @@ public extension Ortto {
      Send push token to Ortto API
      */
     internal func updatePushToken(token: PushToken, force: Bool = false) {
-        PushMessaging.shared.token = token
+        if force {
+            // Re-send even if the token is unchanged — needed when the session or
+            // permission changed after the token was first cached.
+            PushMessaging.shared.sendPushRegistration(token)
+        } else {
+            PushMessaging.shared.token = token
+        }
     }
 
     /**

--- a/Sources/PushMessaging/PushMessaging.swift
+++ b/Sources/PushMessaging/PushMessaging.swift
@@ -71,23 +71,32 @@ public class PushMessaging {
 
             if let existingToken = Ortto.shared.preferences.getObject(key: "token", type: PushToken.self),
                existingToken == newToken {
-                Ortto.log().info("PushMessaging@token.set session_id not changed")
+                Ortto.log().info("PushMessaging@token.set unchanged token; skipping (call dispatchPushRequest() to force a re-send)")
                 return
             }
 
-            registerDeviceToken(
-                sessionID: Ortto.shared.userStorage.session,
-                token: newToken
-            ) { (response: PushRegistrationResponse?) in
-                Ortto.shared.preferences.setObject(object: newToken, key: "token")
+            sendPushRegistration(newToken)
+        }
+    }
 
-                guard let sessionID = response?.sessionId else {
-                    Ortto.log().info("PushMessaging@token.set res returned no session_id")
-                    return
-                }
-
-                Ortto.shared.setSessionID(sessionID)
+    /// Sends the token + permission to Ortto. Bypasses the unchanged-token skip in the
+    /// setter, so it also re-sends when the session/permission changed after the token
+    /// was first cached (e.g. identify completed after the token arrived).
+    func sendPushRegistration(_ newToken: PushToken) {
+        registerDeviceToken(
+            sessionID: Ortto.shared.userStorage.session,
+            token: newToken
+        ) { (response: PushRegistrationResponse?) in
+            guard let sessionID = response?.sessionId else {
+                // Send failed — don't cache the token, so the next dispatch retries
+                // instead of being skipped by the unchanged-token check.
+                Ortto.log().info("PushMessaging@token.set send failed; not caching token (will retry)")
+                return
             }
+
+            // Cache only after a successful send.
+            Ortto.shared.preferences.setObject(object: newToken, key: "token")
+            Ortto.shared.setSessionID(sessionID)
         }
     }
 

--- a/Sources/PushMessaging/PushMessaging.swift
+++ b/Sources/PushMessaging/PushMessaging.swift
@@ -69,6 +69,11 @@ public class PushMessaging {
                 return
             }
 
+            // Dedup guard. The token is only ever cached after a successful send (see
+            // sendPushRegistration), so "already cached" means "already registered" —
+            // safe to skip. A failed send leaves the cache empty, so the next attempt
+            // falls through here and sends. To re-send a still-current token (e.g. the
+            // session changed), use dispatchPushRequest(), which bypasses this guard.
             if let existingToken = Ortto.shared.preferences.getObject(key: "token", type: PushToken.self),
                existingToken == newToken {
                 Ortto.log().info("PushMessaging@token.set unchanged token; skipping (call dispatchPushRequest() to force a re-send)")
@@ -79,24 +84,26 @@ public class PushMessaging {
         }
     }
 
-    /// Sends the token + permission to Ortto. Bypasses the unchanged-token skip in the
-    /// setter, so it also re-sends when the session/permission changed after the token
-    /// was first cached (e.g. identify completed after the token arrived).
+    /// Sends the token + permission to Ortto and caches the token only on success.
+    /// Skips the setter's unchanged-token guard, so it also re-sends a still-current
+    /// token when the session/permission changed (e.g. identify completed after the
+    /// token arrived).
     func sendPushRegistration(_ newToken: PushToken) {
         registerDeviceToken(
             sessionID: Ortto.shared.userStorage.session,
             token: newToken
         ) { (response: PushRegistrationResponse?) in
-            guard let sessionID = response?.sessionId else {
-                // Send failed — don't cache the token, so the next dispatch retries
-                // instead of being skipped by the unchanged-token check.
+            // A nil response means the request failed — the API layer collapses any
+            // error to nil (ApiManager.sendPushPermission). Don't cache on failure, so
+            // the next attempt isn't skipped by the setter's unchanged-token guard.
+            guard let response else {
                 Ortto.log().info("PushMessaging@token.set send failed; not caching token (will retry)")
                 return
             }
 
-            // Cache only after a successful send.
+            // Succeeded: cache the token now and adopt the returned session.
             Ortto.shared.preferences.setObject(object: newToken, key: "token")
-            Ortto.shared.setSessionID(sessionID)
+            Ortto.shared.setSessionID(response.sessionId)
         }
     }
 


### PR DESCRIPTION
## What this fixes

- fixes device silently not registering for push when the first registration request fails.
- fixes the new session id never reaching the server when `identify` completes after the token arrives.

Together these are why a freshly-identified user could show no push permission on the dashboard despite a valid token being present on-device.
