### PR TITLE
Fix: device never re-registers for push when first registration fails or identity arrives late

### DIFF
--- a/Sources/PushMessaging/Ortto+PushMessaging.swift
+++ b/Sources/PushMessaging/Ortto+PushMessaging.swift
@@ -29,28 +29,28 @@ public extension Ortto {
     }
 
     /**
-     Send push token to Ortto API
+     Store the device token and register it with Ortto unless it's already registered.
      */
-    internal func updatePushToken(token: PushToken, force: Bool = false) {
+    internal func updatePushToken(token: PushToken) {
         PushMessaging.shared.token = token
     }
 
     /**
-     Update push token
+     A new device token arrived from the OS — store it and register.
      */
     internal func dispatchPushRequest(_ token: PushToken) {
         updatePushToken(token: token)
     }
 
     /**
-     Update push token
+     Register the stored token with Ortto. Skips the network call when that token is already
+     registered, and retries when an earlier attempt failed — so it's safe to call often.
      */
     func dispatchPushRequest() {
         guard let token = PushMessaging.shared.token else {
             Ortto.log().info("Ortto+PushMessaging@dispatchPushRequest.cancel")
             return
         }
-
-        updatePushToken(token: token, force: true)
+        PushMessaging.shared.sendPushRegistration(token)
     }
 }

--- a/Sources/PushMessaging/Ortto+PushMessaging.swift
+++ b/Sources/PushMessaging/Ortto+PushMessaging.swift
@@ -23,29 +23,25 @@ public extension Ortto {
 
     func clearIdentity(_ completion: @escaping (PushRegistrationResponse?) -> Void) {
         MessagingService.shared.clearIdentity { response in
-            Ortto.shared.clearData()
-            completion(response)
+            // Deliver on main (like identify) — clears identity only; the token isn't identity.
+            DispatchQueue.main.async {
+                Ortto.shared.userStorage.session = nil
+                Ortto.shared.userStorage.user = nil
+                PushMessaging.shared.clearRegistration()
+                completion(response)
+            }
         }
     }
 
-    /**
-     Store the device token and register it with Ortto unless it's already registered.
-     */
     internal func updatePushToken(token: PushToken) {
         PushMessaging.shared.token = token
     }
 
-    /**
-     A new device token arrived from the OS — store it and register.
-     */
     internal func dispatchPushRequest(_ token: PushToken) {
         updatePushToken(token: token)
     }
 
-    /**
-     Register the stored token with Ortto. Skips the network call when that token is already
-     registered, and retries when an earlier attempt failed — so it's safe to call often.
-     */
+    /// Re-registers the stored token (skips if already registered, retries after a failure).
     func dispatchPushRequest() {
         guard let token = PushMessaging.shared.token else {
             Ortto.log().info("Ortto+PushMessaging@dispatchPushRequest.cancel")

--- a/Sources/PushMessaging/PushMessaging.swift
+++ b/Sources/PushMessaging/PushMessaging.swift
@@ -53,41 +53,56 @@ public class PushMessaging {
         }
         set {
             Ortto.shared.preferences.setString(newValue.rawValue, key: "pushPermission")
-
         }
     }
 
+    /// The current device token from the OS. Stored the moment it arrives — even if the
+    /// registration below fails — so it can be retried later without the app re-supplying it.
     public var token: PushToken? {
         get {
             Ortto.shared.preferences.getObject(key: "token", type: PushToken.self)
         }
         set {
             guard let newToken = newValue else {
-                // If new value is nil, remove the existing token
                 Ortto.shared.preferences.setObject(object: nil as PushToken?, key: "token")
-                Ortto.log().info("PushMessaging@token.set removing token")
+                latestRegistration = nil
+                Ortto.log().info("PushMessaging@token forgotten")
                 return
             }
+            Ortto.shared.preferences.setObject(object: newToken, key: "token")
+            sendPushRegistration(newToken)
+        }
+    }
 
-            if let existingToken = Ortto.shared.preferences.getObject(key: "token", type: PushToken.self),
-               existingToken == newToken {
-                Ortto.log().info("PushMessaging@token.set session_id not changed")
+    /// A successful registration: the token we registered and when.
+    private struct Registration: Codable {
+        let token: PushToken
+        let date: Date
+    }
+
+    /// The latest registration Ortto confirmed. Written only on success, and compared against
+    /// an incoming token to decide whether a new registration is actually needed.
+    private var latestRegistration: Registration? {
+        get { Ortto.shared.preferences.getObject(key: "latestRegistration", type: Registration.self) }
+        set { Ortto.shared.preferences.setObject(object: newValue as Registration?, key: "latestRegistration") }
+    }
+
+    /// Registers the token with Ortto, unless it's already the registered token. Safe to call as
+    /// often as you like — `dispatchPushRequest()` runs this every time — it only hits the network
+    /// for a token Ortto hasn't confirmed yet, including retrying after an earlier attempt failed.
+    func sendPushRegistration(_ token: PushToken) {
+        if let latest = latestRegistration, latest.token == token {
+            Ortto.log().info("PushMessaging@registration skip; token already registered \(latest.date)")
+            return
+        }
+
+        registerDeviceToken(sessionID: Ortto.shared.userStorage.session, token: token) { (response: PushRegistrationResponse?) in
+            guard let response else {
+                Ortto.log().info("PushMessaging@registration failed; token kept for retry")
                 return
             }
-
-            registerDeviceToken(
-                sessionID: Ortto.shared.userStorage.session,
-                token: newToken
-            ) { (response: PushRegistrationResponse?) in
-                Ortto.shared.preferences.setObject(object: newToken, key: "token")
-
-                guard let sessionID = response?.sessionId else {
-                    Ortto.log().info("PushMessaging@token.set res returned no session_id")
-                    return
-                }
-
-                Ortto.shared.setSessionID(sessionID)
-            }
+            self.latestRegistration = Registration(token: token, date: Date())
+            Ortto.shared.setSessionID(response.sessionId)
         }
     }
 

--- a/Sources/PushMessaging/PushMessaging.swift
+++ b/Sources/PushMessaging/PushMessaging.swift
@@ -56,8 +56,7 @@ public class PushMessaging {
         }
     }
 
-    /// The current device token from the OS. Stored the moment it arrives — even if the
-    /// registration below fails — so it can be retried later without the app re-supplying it.
+    /// The device token from the OS. Stored on arrival (even if registration fails) so it can be retried.
     public var token: PushToken? {
         get {
             Ortto.shared.preferences.getObject(key: "token", type: PushToken.self)
@@ -74,23 +73,26 @@ public class PushMessaging {
         }
     }
 
+    /// Clears the registration record (keeps the device token) so the next user re-registers.
+    func clearRegistration() {
+        latestRegistration = nil
+    }
+
     /// A successful registration: the token we registered and when.
     private struct Registration: Codable {
         let token: PushToken
         let date: Date
     }
 
-    /// The latest registration Ortto confirmed. Written only on success, and compared against
-    /// an incoming token to decide whether a new registration is actually needed.
+    /// The last registration Ortto confirmed (written only on success); used to dedup.
     private var latestRegistration: Registration? {
         get { Ortto.shared.preferences.getObject(key: "latestRegistration", type: Registration.self) }
         set { Ortto.shared.preferences.setObject(object: newValue as Registration?, key: "latestRegistration") }
     }
 
-    /// Registers the token with Ortto, unless it's already the registered token. Safe to call as
-    /// often as you like — `dispatchPushRequest()` runs this every time — it only hits the network
-    /// for a token Ortto hasn't confirmed yet, including retrying after an earlier attempt failed.
+    /// Registers the token unless it's already registered. Safe to call repeatedly.
     func sendPushRegistration(_ token: PushToken) {
+        // Dedup on token, not session: contact switches clear this via clearIdentity.
         if let latest = latestRegistration, latest.token == token {
             Ortto.log().info("PushMessaging@registration skip; token already registered \(latest.date)")
             return

--- a/Tests/OrttoSDKTests/PushMessagingRegistrationTests.swift
+++ b/Tests/OrttoSDKTests/PushMessagingRegistrationTests.swift
@@ -91,6 +91,35 @@ final class PushMessagingRegistrationTests: OrttoTestCase {
         wait(for: [noFurtherSend], timeout: 0.5)
     }
 
+    /// Logout clears the identity and the registration record but keeps the device token, so the
+    /// next user re-registers the same device instead of being stuck with no token until the OS
+    /// re-delivers it. (The prior contact is disabled by clearIdentity's permission:false call.)
+    func testLogoutKeepsDeviceTokenAndReRegistersForNextUser() {
+        mock.shouldSucceed = true
+
+        // Register for the first user.
+        let registered = registeredExpectation()
+        PushMessaging.shared.token = token
+        wait(for: [registered], timeout: 2)
+        XCTAssertEqual(Ortto.shared.userStorage.session, "srv-session")
+
+        // Log out.
+        let loggedOut = expectation(description: "logout")
+        Ortto.shared.clearIdentity { _ in loggedOut.fulfill() }
+        wait(for: [loggedOut], timeout: 2)
+
+        // Device token survives; identity is gone.
+        XCTAssertEqual(PushMessaging.shared.token, token)
+        XCTAssertNil(Ortto.shared.userStorage.session)
+
+        // A different user identifies → the same token re-registers (record was cleared, no skip).
+        Ortto.shared.userStorage.session = "user-b-session"
+        let reRegister = expectation(description: "re-register for next user")
+        mock.onSend = { reRegister.fulfill() }
+        Ortto.shared.dispatchPushRequest()
+        wait(for: [reRegister], timeout: 2)
+    }
+
     /// An expectation satisfied once the session the server returned has been persisted —
     /// proof that a registration round-tripped (send + completion) successfully.
     private func registeredExpectation() -> XCTestExpectation {

--- a/Tests/OrttoSDKTests/PushMessagingRegistrationTests.swift
+++ b/Tests/OrttoSDKTests/PushMessagingRegistrationTests.swift
@@ -1,0 +1,127 @@
+//
+//  PushMessagingRegistrationTests.swift
+//
+//  Covers token registration: a failed first attempt must keep the cached token so a
+//  later trigger (e.g. identity/session arriving) can retry, while a steady-state
+//  re-check must not re-send and spam duplicate registration events.
+//
+
+import Foundation
+@testable import OrttoPushMessaging
+@testable import OrttoSDKCore
+import XCTest
+
+final class PushMessagingRegistrationTests: OrttoTestCase {
+
+    private let token = PushToken(value: "device-token", type: "apns")
+
+    private var mock: RecordingApiManager!
+    private var savedApiManager: ApiManagerInterface!
+    private var savedPreferences: PreferencesInterface!
+    private var savedUserStorage: UserStorage!
+
+    override func setUp() {
+        super.setUp()
+
+        // Isolate global SDK state so each test starts from a clean slate.
+        savedApiManager = Ortto.shared.apiManager
+        savedPreferences = Ortto.shared.preferences
+        savedUserStorage = Ortto.shared.userStorage
+
+        let preferences = OrttoPreferencesManager()
+        preferences.clear()
+        Ortto.shared.preferences = preferences
+        Ortto.shared.userStorage = OrttoUserStorage(preferences)
+
+        mock = RecordingApiManager()
+        Ortto.shared.apiManager = mock
+
+        // .Accept resolves synchronously without touching UNUserNotificationCenter.
+        PushMessaging.shared.permission = .Accept
+    }
+
+    override func tearDown() {
+        Ortto.shared.preferences.clear()
+        Ortto.shared.apiManager = savedApiManager
+        Ortto.shared.preferences = savedPreferences
+        Ortto.shared.userStorage = savedUserStorage
+        super.tearDown()
+    }
+
+    /// The core regression: if the first registration fails, the token must be kept and a
+    /// later re-check must retry it — without the app having to supply the token again.
+    func testFailedFirstRegistrationIsRetriedOnNextRequest() {
+        // 1. First attempt fails.
+        mock.shouldSucceed = false
+        let firstAttempt = expectation(description: "first registration attempt")
+        mock.onSend = { firstAttempt.fulfill() }
+
+        PushMessaging.shared.token = token
+        wait(for: [firstAttempt], timeout: 2)
+
+        // Token is still known despite the failure, and nothing got registered.
+        XCTAssertEqual(PushMessaging.shared.token, token)
+        XCTAssertNil(Ortto.shared.userStorage.session)
+
+        // 2. Session/identity becomes available → the next request retries and now succeeds.
+        mock.onSend = nil
+        mock.shouldSucceed = true
+        let registered = registeredExpectation()
+
+        Ortto.shared.dispatchPushRequest()
+        wait(for: [registered], timeout: 2)
+
+        XCTAssertEqual(Ortto.shared.userStorage.session, "srv-session")
+    }
+
+    /// The same token arriving again (e.g. on the next launch) must not re-register — otherwise
+    /// every launch would create a duplicate registration event server-side.
+    func testSameTokenArrivingAgainIsNotReRegistered() {
+        mock.shouldSucceed = true
+        let registered = registeredExpectation()
+
+        PushMessaging.shared.token = token
+        wait(for: [registered], timeout: 2)
+
+        let noFurtherSend = expectation(description: "no further registration")
+        noFurtherSend.isInverted = true
+        mock.onSend = { noFurtherSend.fulfill() }
+
+        PushMessaging.shared.token = token
+        wait(for: [noFurtherSend], timeout: 0.5)
+    }
+
+    /// An expectation satisfied once the session the server returned has been persisted —
+    /// proof that a registration round-tripped (send + completion) successfully.
+    private func registeredExpectation() -> XCTestExpectation {
+        XCTNSPredicateExpectation(
+            predicate: NSPredicate { _, _ in
+                Ortto.shared.userStorage.session == "srv-session"
+            },
+            object: nil
+        )
+    }
+}
+
+/// Drives reconciliation deterministically: counts push-permission sends, lets a test toggle
+/// success/failure, and returns the canned `session_id` the assertions key off.
+private final class RecordingApiManager: ApiManagerInterface {
+    var appKey: String? = "app-key"
+    var shouldSucceed = true
+    var onSend: (() -> Void)?
+
+    func sendRegisterIdentity(_: UserStorage) async throws -> IdentityRegistrationResponse? {
+        nil
+    }
+
+    func sendLinkTracking(_: URL) async throws {}
+
+    func send<R: OrttoAPIRequest>(_: R) async throws -> R.Response {
+        onSend?()
+        guard shouldSucceed else {
+            throw OrttoHTTPError.network(URLError(.timedOut))
+        }
+        let json = Data(#"{"session_id":"srv-session"}"#.utf8)
+        return try JSONDecoder().decode(R.Response.self, from: json)
+    }
+}


### PR DESCRIPTION
- fixes a device silently never registering for push when the first registration request fails.*
- fixes the new session id never reaching the server when `identify` completes after the token arrives.